### PR TITLE
added client groups as last column of admin stats [SCT-658]

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -396,6 +396,7 @@ define([
                         { text: 'End Time', id: 'finish_time', isSortable: true },
                         { text: 'Run Time', id: 'run_time', isSortable: true },
                         { text: 'Status', id: 'result', isSortable: true },
+                        { text: 'Client Groups', id: 'client_groups', isSortable: true },
                     ],
                 };
 
@@ -849,6 +850,10 @@ define([
                     job.queue_time = job.exec_start_time
                       ? job.exec_start_time - job.creation_time
                       : 0;
+
+                    if (job.client_groups) {
+                      job.client_groups = job.client_groups.join(',');
+                    }
 
                     self.adminRecentRuns.push(job);
 


### PR DESCRIPTION
Paramvir requested adding the client groups field as the last column into the admin stats view.

So, this adds that in. This should head up to CI as soon as we can, but not meander out to prod until it's looked at and approved.