### PR TITLE
frontend caching of catalog stats [SCT-822]

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/plugin/modules/widgets/kbaseCatalogBrowser.js
@@ -1,3 +1,4 @@
+console.log("CATALOG BROWSER");
 define([
     'jquery',
     'bluebird',

--- a/src/plugin/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/plugin/modules/widgets/kbaseCatalogBrowser.js
@@ -1,4 +1,3 @@
-console.log("CATALOG BROWSER");
 define([
     'jquery',
     'bluebird',

--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -265,7 +265,7 @@ define([
                                                 $container.removeClass('kbcb-active-filter');
                                             }
 
-                                            getLatestRunsInCustomRange(self.thenDate, self.nowDate);
+                                            getLatestRunsInCustomRange(self.thenDate, self.nowDate, true);
 
                                         })
                                 )
@@ -278,13 +278,13 @@ define([
                        and re-calls the get_app_metrics() function. It'll blank out the table and show the loading element and then re-call
                        the function. Once it's back, it'll update the updateFunction and re-populate the table.
                     */
-                var getLatestRunsInCustomRange = function (fromDate, toDate) {
+                var getLatestRunsInCustomRange = function (fromDate, toDate, cached) {
                     self.thenDate = fromDate;
                     self.nowDate = toDate;
 
                     var currentTime = ( new Date() ).getTime();
 
-                    if (self.lastRunTime + self.options.rerunDuration * 1000 > currentTime) {
+                    if (cached && self.lastRunTime + self.options.rerunDuration * 1000 > currentTime) {
                       var rows = makeRecentRunsTableRows();
                       $adminRecentRunsTable.currentPage = 0;
                       $adminRecentRunsTable.options.updateFunction = self.createDynamicUpdateFunction(adminRecentRunsConfig, rows);

--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -41,6 +41,8 @@ define([
             includeUserRunSummary: true,
             includePublicStats: true,
             useUserRecentRuns: false,
+
+            rerunDuration : 30,
         },
 
         // clients to the catalog service and the NarrativeMethodStore
@@ -247,26 +249,27 @@ define([
                                     $('<input>')
                                         .attr('type', 'checkbox')
                                         .addClass('form-check-input')
+                                        .on('click', function (e) {
+                                            var $target = $(e.target);
+                                            var $container = $target.prop('tagName') === 'LABEL'
+                                                ? $target
+                                                : $target.parent()
+                                                ;
+
+                                            activeFilters[filter] = $target.prop('checked');
+
+                                            if (activeFilters[filter]) {
+                                                $container.addClass('kbcb-active-filter');
+                                            }
+                                            else {
+                                                $container.removeClass('kbcb-active-filter');
+                                            }
+
+                                            getLatestRunsInCustomRange(self.thenDate, self.nowDate);
+
+                                        })
                                 )
                                 .append(' ' + filterLabel + ' ')
-                                .on('click', function (e) {
-                                    var $target = $(e.target);
-                                    var $container = $target.prop('tagName') === 'LABEL'
-                                        ? $target
-                                        : $target.parent()
-                                        ;
-
-                                    activeFilters[filter] = $target.prop('checked');
-
-                                    if (activeFilters[filter]) {
-                                        $container.addClass('kbcb-active-filter');
-                                    }
-                                    else {
-                                        $container.removeClass('kbcb-active-filter');
-                                    }
-
-                                    getLatestRunsInCustomRange(self.thenDate, self.nowDate);
-                                })
                         );
 
                 };
@@ -278,6 +281,16 @@ define([
                 var getLatestRunsInCustomRange = function (fromDate, toDate) {
                     self.thenDate = fromDate;
                     self.nowDate = toDate;
+
+                    var currentTime = ( new Date() ).getTime();
+
+                    if (self.lastRunTime + self.options.rerunDuration * 1000 > currentTime) {
+                      var rows = makeRecentRunsTableRows();
+                      $adminRecentRunsTable.currentPage = 0;
+                      $adminRecentRunsTable.options.updateFunction = self.createDynamicUpdateFunction(adminRecentRunsConfig, rows);
+                      $adminRecentRunsTable.getNewData();
+                      return;
+                    }
 
                     $adminRecentRunsTable.$tBody.empty();
                     $adminRecentRunsTable.$loadingElement.show();
@@ -796,7 +809,9 @@ define([
                 return Promise.try(function () { });
             }
 
-            var seconds = (new Date().getTime() / 1000) - 172800;
+            self.lastRunTime = ( new Date() ).getTime();
+
+            var seconds = (self.lastRunTime / 1000) - 172800;
 
             var now = self.nowDate || (new Date()).getTime();
             var then = self.thenDate || now - self.options.numHours * 60 * 60 * 1000;


### PR DESCRIPTION
The front end widget showing app stats was producing too many requests to the metrics service.

This change does two things:
* If one of the filter buttons is clicked (Finished, Queued, Running, Success, Error), it'll only re-filter the existing rows and not fetch new ones. UNLESS the user re-filters it after 30 seconds, in which case a new request will be issued.
* Discovered that each click on the label was previously generating TWO requests to the service, making it even worse. It's irrelevant to fix it now, since the caching component in the last bullet point would resolve it, but nonetheless also moves the onClick handler from the label to the button to ensure that only one re-filter/re-query action is ever fired.

This should get out to production reasonably quickly, if possible, since it's a user facing issue.