### PR TITLE
calculates run_time/finish_time as necessary

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -746,9 +746,9 @@ define([
             return self.checkIsAdmin()
                 .then(function () {
                     if (self.isAdmin) {
-                        return self.getAdminUserStats()
+                        return self.getAdminLatestRuns()
                             .then(function () {
-                                return self.getAdminLatestRuns();
+                                return self.getAdminUserStats();
                             });
                     } else {
                         return Promise.try(function () { });
@@ -871,6 +871,17 @@ define([
 
                     if (job.narrative_name) {
                       job.narrative_name = '<a href="/narrative/ws.' + job.wsid + '.obj.' + job.narrative_objNo + '" target="_blank">' + job.narrative_name + '</a>';
+                    }
+
+                    if (job.finish_time) {
+                      job.run_time = job.finish_time - job.exec_start_time;
+                    }
+                    else if (job.modification_time) {
+                      job.run_time = job.modification_time - job.exec_start_time;
+                    }
+
+                    if ( job.complete && ! job.finish_time) {
+                      job.finish_time = job.modification_time;
                     }
 
                     job.queue_time = job.exec_start_time


### PR DESCRIPTION
Hopefully the last one for a while. Fixes a bug in the display of the Run Time field (the run_time key was dropped from the return object), and fixes a bug in initial display of jobs for a non-admin user (it was trying to load admin stats first, failing, and never loading user level job stats as a result)