### PR TITLE
fixed queued issues

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -876,8 +876,8 @@ define([
                     if (job.finish_time) {
                       job.run_time = job.finish_time - job.exec_start_time;
                     }
-                    else if (job.modification_time && job.exec_start_time) {
-                      job.run_time = job.modification_time - job.exec_start_time;
+                    else if (job.exec_start_time) {
+                      job.run_time = Date.now() - job.exec_start_time;
                     }
 
                     if ( job.complete && ! job.finish_time) {

--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -200,7 +200,7 @@ define([
                     */
                 var filters = {
                     finished: function (row) { return row.complete === true; },
-                    queued: function (row) { return row.exec_start_time === undefined; },
+                    queued: function (row) { return row.exec_start_time === undefined || row.exec_start_time === null; },
                     running: function (row) { return row.complete === false; },
                     success: function (row) { return row.complete === true && row.error !== true; },
                     error: function (row) { return row.complete === true && row.error === true; }
@@ -876,7 +876,7 @@ define([
                     if (job.finish_time) {
                       job.run_time = job.finish_time - job.exec_start_time;
                     }
-                    else if (job.modification_time) {
+                    else if (job.modification_time && job.exec_start_time) {
                       job.run_time = job.modification_time - job.exec_start_time;
                     }
 


### PR DESCRIPTION
Resolves two issues—

* A queued job would show a crazy high "run time" since it was calculating the modification_time - exec_start_time. Since it was queued, it has no start time. Now only calculates run time if it has exec_start_time.
* The results were changed - previously a job which was queued would have an undefined exec_start_time, now it's null. Handles both cases.