### PR TITLE
Change the util to utilities so it can show up in the App Catalog PTV-1048

### DIFF
--- a/src/plugin/modules/data/categories.yml
+++ b/src/plugin/modules/data/categories.yml
@@ -21,4 +21,4 @@ orderings:
         - metabolic_modeling
         - expression
         - communities
-        - utilities
+        - util


### PR DESCRIPTION
PTV-1048
@scanon @eapearson @thomasoniii This typo was casing the Utilities to be absent from the App Catalog. They are in the App Panel but not the catalog.