### PR TITLE
Job Browser kill button [PTV-990]

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -540,7 +540,7 @@ define([
                                     $('<div>').addClass('col-md-12')
                                         .append(
                                             $('<h4>')
-                                                .append('!!!Recent Runs (submitted in ')
+                                                .append('Recent Runs (submitted in ')
                                                 .append(self.numHoursField)
                                                 .append('):')
                                         )


### PR DESCRIPTION
This adds a kill button to the jobs browser. It'll confirm for the user whether they want to kill the job.

Also adds a new "Canceled" status in cyan. Previously, canceled jobs would show up as "Success" in green.

If we could get this to CI tomorrow for demo purposes, that'd be awesome.

CAVEATS:
* UI may not be what we want, but let's get the functionality out now.
* The narrative itself has an error. When you kill a job via the job browser in this manner, the narrative will freeze the cell button on "Cancel" and claim that it's waiting in the queue. Drilling into the job status will show that the job is canceled, but the button persists. There doesn't appear to be a way to force the "Cancel" button to go away. But this is a bug in the narrative side of things.