### PR TITLE
whoops. no cancel button on errored jobs

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -874,7 +874,7 @@ define([
                         job.result += ' <button class="btn btn-default btn-xs" data-log-job-id="' + job.job_id + '"> <i class="fa fa-file-text"></i></button>';
                     }
 
-                    if (job.exec_start_time && !job.finish_time) {
+                    if (job.exec_start_time && !job.finish_time && !job.error) {
                       job.result += ' <button class="btn btn-danger btn-xs" data-cancel-job-id="' + job.job_id + '"> <i class="fa fa-ban"></i></button>';
                     }
 


### PR DESCRIPTION
Missed a case. error'ed jobs don't report a finish_time, so we can't just check on that.

This was previously presenting a cancel button to a job that's already finished, but has an error. Now it won't show for jobs with an error flag.