### PR TITLE
Update is_admin call

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogIndex.js
+++ b/src/plugin/modules/widgets/kbaseCatalogIndex.js
@@ -162,8 +162,7 @@ define([
 
         checkIsAdmin: function () {
             var self = this;
-            var me = self.runtime.service('session').getUsername();
-            return self.catalog.is_admin(me)
+            return self.catalog.is_admin()
                 .then(function (result) {
                     if (result) { self.isAdmin = true; }
                 })


### PR DESCRIPTION
Now that catalog uses tokens to determine admin status we need to change this call to avoid passing a username

This would need to be deployed in CI only