### PR TITLE
Update links for generic types

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogAppViewer.js
+++ b/src/plugin/modules/widgets/kbaseCatalogAppViewer.js
@@ -869,15 +869,14 @@ define([
                         $.each(
                             sortedParams[ui_class],
                             function (idx, param) {
-
-                                var types = '';
-
+                                let types = '';
                                 if (param.text_options && param.text_options.valid_ws_types) {
                                     types = $.jqElem('i').append(' ');
-                                    for (var ty = 0; ty < param.text_options.valid_ws_types.length; ty++) {
+                                    for (let ty = 0; ty < param.text_options.valid_ws_types.length; ty++) {
                                         if (ty > 0) { types.append(', '); }
-                                        var typeName = param.text_options.valid_ws_types[ty];
-                                        types.append('<a href="#spec/type/' + typeName + '">' + typeName + '</a>');
+                                        const typeName = param.text_options.valid_ws_types[ty];
+                                        const url_prefix = typeName.includes(".") ? "type" : "module";
+                                        types.append(`<a href="#spec/${url_prefix}/${typeName}">${typeName}</a>`);
                                     }
                                 }
 

--- a/src/plugin/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/plugin/modules/widgets/kbaseCatalogBrowser.js
@@ -1049,100 +1049,57 @@ define([
             this.$appListPanel.append($listContainer);
         },
 
-        renderbyInputTypes: function () {
-            // get and sort the type list
-            var types = [];
-            for (var k in this.inputTypes) {
-                types.push(k);
-            }
-            types.sort();
-
+        renderTypes: function (types, type_field) {
             // create the sections per type
-            var $typeDivLookup = {};
-            for (k = 0; k < types.length; k++) {
-                var $section = $('<div>').addClass('catalog-section');
-                var $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
-                $typeDivLookup[types[k]] = $typeDiv;
+            let $typeDivLookup = {};
+            types.forEach((type) => {
+                const $section = $('<div>').addClass('catalog-section');
+                const $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
+                const url_prefix = type.includes(".") ? "type" : "module";
+                $typeDivLookup[type] = $typeDiv;
+
                 $section.append(
-                    $('<div>').css({ 'color': '#777' })
-                        .append($('<h4>').append($('<a href="#spec/type/' + types[k] + '">').append(types[k]))));
+                    $('<div>').append($('<h4>')
+                        .append($(`<a href="#spec/${url_prefix}/${type}">`).append(type))));
                 $section.append($typeDiv);
                 this.$appListPanel.append($section);
-            }
+            });
 
             // create section for apps without an input type
-            $section = $('<div>').addClass('catalog-section');
-            $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
+            const $section = $('<div>').addClass('catalog-section');
+            const $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
             $typeDivLookup.none = $typeDiv;
             $section.append(
-                $('<div>').css({ 'color': '#777' })
-                    .append($('<h4>').append($('<span>None</span>').append(types[k]))));
+                $('<div>').css({'color': '#777'})
+                    .append($('<h4>').append($('<span>None</span>'))));
             $section.append($typeDiv);
             this.$appListPanel.append($section);
 
             // render the app list
-            for (k = 0; k < this.appList.length; k++) {
-                this.appList[k].clearCardsAddedCount();
-                if (this.appList[k].info.app_type === 'app') {
-                    if (this.appList[k].info.input_types.length > 0) {
-                        var input_types = this.appList[k].info.input_types;
-                        for (var i = 0; i < input_types.length; i++) {
-                            $typeDivLookup[input_types[i]].append(this.appList[k].getNewCardDiv());
-                        }
+            this.appList.forEach((app) => {
+                app.clearCardsAddedCount();
+                if (app.info.app_type === 'app') {
+                    if (app.info[type_field].length > 0) {
+                        app.info[type_field].forEach((type) => {
+                            $typeDivLookup[type].append(app.getNewCardDiv());
+                        });
                     } else {
-                        $typeDivLookup.none.append(this.appList[k].getNewCardDiv());
+                        $typeDivLookup.none.append(app.getNewCardDiv());
                     }
                 }
-            }
+            })
+        }, renderbyInputTypes: function () {
+            // get and sort the type list
+            const types = Object.keys(this.inputTypes).sort();
+            const type_field = "input_types";
+            this.renderTypes(types, type_field);
         },
 
         renderByOutputTypes: function () {
             // get and sort the type list
-            var types = [];
-            for (var k in this.outputTypes) {
-                types.push(k);
-            }
-            types.sort();
-
-            // create the sections per output type
-            var $typeDivLookup = {};
-            for (k = 0; k < types.length; k++) {
-                var $section = $('<div>').addClass('catalog-section');
-                var $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
-                $typeDivLookup[types[k]] = $typeDiv;
-                $section.append(
-                    $('<div>').css({ 'color': '#777' })
-                        .append($('<h4>').append($('<a href="#spec/type/' + types[k] + '">').append(types[k]))));
-                $section.append($typeDiv);
-                this.$appListPanel.append($section);
-            }
-
-
-            // create section for apps without an output type
-            $section = $('<div>').addClass('catalog-section');
-            $typeDiv = $('<div>').addClass('kbcb-app-card-list-container');
-            $typeDivLookup.none = $typeDiv;
-            $section.append(
-                $('<div>').css({ 'color': '#777' })
-                    .append($('<h4>').append($('<span>None</span>').append(types[k]))));
-            $section.append($typeDiv);
-            this.$appListPanel.append($section);
-
-            // render the app list
-            for (k = 0; k < this.appList.length; k++) {
-                this.appList[k].clearCardsAddedCount();
-
-                if (this.appList[k].info.app_type === 'app') {
-                    if (this.appList[k].info.output_types.length > 0) {
-                        var output_types = this.appList[k].info.output_types;
-                        for (var i = 0; i < output_types.length; i++) {
-                            $typeDivLookup[output_types[i]].append(this.appList[k].getNewCardDiv());
-                        }
-                    } else {
-                        $typeDivLookup.none.append(this.appList[k].getNewCardDiv());
-                    }
-                }
-            }
+            const types = Object.keys(this.outputTypes).sort();
+            const type_field = "output_types";
+            this.renderTypes(types, type_field);
         },
 
         renderByRuns: function () {


### PR DESCRIPTION
Basically, apps can specify only the module name (not the full type) to allow some flexibility in matching any subtype in the module so I needed to tweak the links to work. I also did some tidying and DRYing while I was at it.