### PR TITLE
Changed state based on status, not exec time

### DIFF
--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -862,7 +862,7 @@ define([
                     if (job.error) {
                         job.result = '<span class="label label-danger">Error</span>';
                     } else if (!job.finish_time) {
-                        job.result = job.exec_start_time
+                        job.result =  job.status === 'in-progress'
                             ? '<span class="label label-warning">Running</span>'
                             : '<span class="label label-warning">Queued</span>';
                     } else if (job.status === 'canceled by user') {
@@ -874,7 +874,7 @@ define([
 
                     // Creates a job log viewer button for any job which has been or is being
                     // run.
-                    if (job.exec_start_time) {
+                    if (job.exec_start_time || job.status === 'canceled by user' ) {
                         job.result += ' <button class="btn btn-default btn-xs" data-log-job-id="' + job.job_id + '"> <i class="fa fa-file-text"></i></button>';
                     }
 

--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -874,7 +874,7 @@ define([
 
                     // Creates a job log viewer button for any job which has been or is being
                     // run.
-                    if (job.exec_start_time || job.status === 'canceled by user' ) {
+                    if (job.exec_start_time) {
                         job.result += ' <button class="btn btn-default btn-xs" data-log-job-id="' + job.job_id + '"> <i class="fa fa-file-text"></i></button>';
                     }
 

--- a/src/plugin/modules/widgets/kbaseCatalogStats.js
+++ b/src/plugin/modules/widgets/kbaseCatalogStats.js
@@ -895,7 +895,7 @@ define([
                     }
 
                     // Calculate elapsed run time for finished and continuing jobs.
-                    if (job.exec_start_time) {
+                    if (job.exec_start_time && job.status !== 'queued') {
                         if (job.complete) {
                             job.run_time = job.modification_time - job.exec_start_time;
                         }  else {
@@ -908,7 +908,7 @@ define([
                     // Calculate elapsed queue time, for finished and continuing jobs.
                     // This just relies on the creation and start times.
                     if (job.creation_time) {
-                        if (job.exec_start_time) {
+                        if (job.exec_start_time && job.status !== 'queued') {
                             // For started jobs, the queue elapsed time is fixed.
                             job.queue_time = job.exec_start_time - job.creation_time;
                         } else {


### PR DESCRIPTION
new changes in NJS display logs for queued/canceled jobs based on exec times FYI

currently, the job browser displays job status as "Running" for queued jobs, because these jobs have been "Started" in NJS

this PR shows the correct status, as it gets it from the status field, instead of the `exec_start_time ` field.

![image](https://user-images.githubusercontent.com/1258634/57487095-e1182080-726c-11e9-8dfd-ad60b2ae0a97.png)
